### PR TITLE
Fix build error

### DIFF
--- a/src/HeadlessProcessor.cpp
+++ b/src/HeadlessProcessor.cpp
@@ -24,6 +24,7 @@
  */
 #include "HeadlessProcessor.h"
 #include <QSettings>
+#include <QDebug>
 #include "Updater.h"
 #include "Common.h"
 #include "GmicStdlibParser.h"


### PR DESCRIPTION
Add a missing include: 

src/HeadlessProcessor.cpp: In member function ‘void HeadlessProcessor::onProcessingFinished()’:
src/HeadlessProcessor.cpp:184:14: error: invalid use of incomplete type ‘class QDebug’
     qWarning() << "Error:" << errorMessage;
              ^
In file included from /home/boud/dev/deps/include/QtCore/qglobal.h:1106:0,
                 from /home/boud/dev/deps/include/QtCore/qtimer.h:37,
                 from /home/boud/dev/deps/include/QtCore/QTimer:1,
                 from include/HeadlessProcessor.h:29,
                 from src/HeadlessProcessor.cpp:25:
/home/boud/dev/deps/include/QtCore/qlogging.h:51:7: error: forward declaration of ‘class QDebug’
 class QDebug;
       ^
Makefile:9534: recipe for target '.obj/HeadlessProcessor.o' failed
make: *** [.obj/HeadlessProcessor.o] Error 1
