### PR TITLE
Create a CMake-based build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,7 +117,8 @@ if (CURL_FOUND)
     set(gmic_qt_LIBRARIES
         ${gmic_qt_LIBRARIES}
         ${CURL_LIBRARIES}
-)        
+    )        
+endif()
 
 add_definitions(-Dgmic_build)
 add_definitions(-Dcimg_use_abort)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,349 @@
+project(gmic-qt)
+
+message(STATUS "Using CMake version: ${CMAKE_VERSION}")
+
+cmake_minimum_required(VERSION 3.1.0 FATAL_ERROR)
+LIST (APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/modules")
+include(FeatureSummary)
+
+set(CMAKE_CXX_STANDARD 11)
+set(MIN_QT_VERSION 5.2.0)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTOUIC OFF)
+set(CMAKE_AUTORCC ON)
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+set (GMIC_QT_HOST "gimp" CACHE STRING "Define for which host qmic-qt will be built: gimp, krita or none.")
+message("Building version:" ${GMIC_QT_HOST})
+
+set (GMIC_PATH "../gmic/src" CACHE STRING "Define the path to the gmic headers")
+message("G'Mic path: " ${GMIC_PATH})
+
+option(PRERELEASE "Set to ON makes this a prelease build")
+if (${PRERELEASE})
+    string(TIMESTAMP PRERELEASE_DATE %y%m%d)
+    message("Prelease date is " ${PRERELEASE_DATE})
+    add_definitions(-Dgmic_prelease=${PRERELEASE_DATE})
+endif()
+
+
+# Required packages
+
+#
+# Qt5 
+#
+find_package(Qt5 ${MIN_QT_VERSION}
+        REQUIRED COMPONENTS
+        Core
+        Gui
+        Widgets
+        Network
+)
+
+#
+# For the translations
+#
+find_package(Qt5LinguistTools REQUIRED)
+
+#
+# PNG
+#
+find_package(PNG REQUIRED)
+add_definitions(${PNG_DEFINITIONS})
+add_definitions(-Dcimg_use_png)
+include_directories(SYSTEM ${PNG_INCLUDE_DIR})
+if (APPLE)
+    # this is not added correctly on OSX -- see http://forum.kde.org/viewtopic.php?f=139&t=101867&p=221242#p221242
+    include_directories(SYSTEM ${PNG_INCLUDE_DIR})
+endif()
+
+#
+# ZLIB
+#
+find_package(ZLIB REQUIRED)
+add_definitions(-Dcimg_use_zlib)
+include_directories(SYSTEM ${ZLIB_INCLUDE_DIRS} )
+
+#
+# FFTW3
+#
+find_package(FFTW3 REQUIRED)
+add_definitions(-Dcimg_use_fftw3 )
+add_definitions(-Dcimg_use_fftw3_singlethread )
+include_directories(${FFTW3_INCLUDE_DIR})
+
+#
+# CURL
+#
+find_package(CURL)
+if (CURL_FOUND)
+    add_definitions(-Dcimg_use_curl)
+    include_directories(SYSTEM ${CURL_INCLUDE_DIRS} )
+endif()
+
+#
+# Test for OpenMP
+#
+find_package(OpenMP)
+set_package_properties(OpenMP PROPERTIES
+    DESCRIPTION "A low-level parallel execution library"
+    URL "http://openmp.org/wp/"
+    TYPE OPTIONAL
+    PURPOSE "Optionally used by gmic-qt")
+    
+if (CMAKE_COMPILER_IS_GNUCC AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 4.8.3 AND OPENMP_FOUND)
+    message("G'Mic: using OpenMP")
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+    add_definitions(-Dcimg_use_openmp)
+    add_definitions(-fopenmp)
+endif()  
+
+
+#
+# add all defines
+#
+
+set(gmic_qt_LIBRARIES
+        Qt5::Core
+        Qt5::Widgets
+        Qt5::Gui
+        Qt5::Network
+        ${PNG_LIBRARIES}
+        ${FFTW3_LIBRARIES}
+        ${ZLIB_LIBRARIES}
+)
+
+if (CURL_FOUND)
+    set(gmic_qt_LIBRARIES
+        ${gmic_qt_LIBRARIES}
+        ${CURL_LIBRARIES}
+)        
+
+add_definitions(-Dgmic_build)
+add_definitions(-Dcimg_use_abort)
+add_definitions(-Dgmic_is_parallel)
+add_definitions(-Dcimg_use_rng)
+add_definitions(-Dgmic_gui)
+add_definitions(-Dcimg_use_abort)
+
+if (UNIX AND NOT APPLE)
+    add_definitions(-Dcimg_display=1)
+    add_definitions(-D_IS_LINUX_)
+    add_definitions(-Dcimg_use_vt100)
+    add_definitions(-D_IS_UNIX_)
+    set(gmic_qt_LIBRARIES
+        ${gmic_qt_LIBRARIES}
+        X11 # XXX: Search for X11: Wayland is coming!
+    )
+        
+endif()
+
+if (APPLE)
+    add_definitions(-Dcimg_display=0)
+    add_definitions(-D_IS_MACOS_)
+    set(CMAKE_MACOSX_RPATH 1)
+    set(BUILD_WITH_INSTALL_RPATH 1)
+    add_definitions(-mmacosx-version-min=10.9 -Wno-macro-redefined -Wno-deprecated-register)
+endif()
+
+if (WINDOWS)
+    add_definitions(-Dcimg_display=2)
+    add_definitions(-DPSAPI_VERSION=1)
+    add_definitions(-Dcimg_appname=gmic)
+    set(gmic_qt_LIBRARIES
+        ${gmic_qt_LIBRARIES}
+        windows pthread psapi gdi32
+    )
+endif()
+
+if (CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
+    message("Debug build")
+    add_definitions(-D_GMIC_QT_DEBUG_)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS}  -fsanitize=address") 
+else()
+    message("Release build")
+    add_definitions(-DQT_NO_DEBUG_OUTPUT)
+endif()
+    
+include_directories(${CMAKE_SOURCE_DIR}/include ${GMIC_PATH})
+    
+set (gmic_qt_SRCS 
+
+    include/ProgressInfoWidget.h
+    include/FilterThread.h 
+    include/MultilineTextParameterWidget.h 
+    include/MainWindow.h 
+    include/ProgressInfoWindow.h 
+    include/BoolParameter.h  
+    include/FiltersTreeFilterItem.h 
+    include/ConstParameter.h 
+    include/FiltersTreeAbstractFilterItem.h 
+    include/LinkParameter.h 
+    include/Common.h 
+    include/PreviewWidget.h 
+    include/ButtonParameter.h 
+    include/ChoiceParameter.h 
+    include/IntParameter.h 
+    include/SearchFieldWidget.h 
+    include/FolderParameter.h 
+    include/ImageTools.h 
+    include/SeparatorParameter.h 
+    include/GmicStdlibParser.h 
+    include/gmic_qt.h 
+    include/FiltersTreeItemDelegate.h 
+    include/NoteParameter.h 
+    include/DialogSettings.h 
+    include/TextParameter.h 
+    include/host.h 
+    include/ParametersCache.h 
+    include/FiltersTreeAbstractItem.h 
+    include/AbstractParameter.h 
+    include/FloatParameter.h 
+    include/ImageConverter.h 
+    include/ColorParameter.h 
+    include/FiltersTreeFaveItem.h 
+    include/Updater.h 
+    include/FiltersTreeFolderItem.h 
+    include/FilterParamsWidget.h 
+    include/InOutPanel.h 
+    include/ClickableLabel.h 
+    include/FileParameter.h 
+    include/HeadlessProcessor.h 
+    include/FiltersVisibilityMap.h 
+    include/HtmlTranslator.h 
+    include/StoredFave.h 
+    include/ZoomLevelSelector.h
+    ${GMIC_PATH}/gmic.h
+
+    src/FolderParameter.cpp 
+    src/ParametersCache.cpp 
+    src/gmic_qt.cpp 
+    src/TextParameter.cpp 
+    src/ColorParameter.cpp  
+    src/FilterParamsWidget.cpp 
+    src/FiltersTreeFaveItem.cpp 
+    src/FiltersTreeAbstractItem.cpp 
+    src/FileParameter.cpp 
+    src/GmicStdlibParser.cpp 
+    src/ImageTools.cpp 
+    src/FiltersTreeFolderItem.cpp 
+    src/ProgressInfoWindow.cpp 
+    src/IntParameter.cpp 
+    src/LayersExtentProxy.cpp 
+    src/FiltersTreeItemDelegate.cpp 
+    src/FilterThread.cpp 
+    src/SeparatorParameter.cpp 
+    src/NoteParameter.cpp 
+    src/MainWindow.cpp  
+    src/ConstParameter.cpp 
+    src/ImageConverter.cpp 
+    src/BoolParameter.cpp 
+    src/DialogSettings.cpp 
+    src/ButtonParameter.cpp 
+    src/FloatParameter.cpp 
+    src/ProgressInfoWidget.cpp 
+    src/AbstractParameter.cpp 
+    src/PreviewWidget.cpp 
+    src/ClickableLabel.cpp 
+    src/FiltersTreeAbstractFilterItem.cpp 
+    src/InOutPanel.cpp 
+    src/LinkParameter.cpp 
+    src/ChoiceParameter.cpp 
+    src/FiltersTreeFilterItem.cpp  
+    src/MultilineTextParameterWidget.cpp 
+    src/SearchFieldWidget.cpp 
+    src/Updater.cpp 
+    src/HeadlessProcessor.cpp 
+    src/FiltersVisibilityMap.cpp 
+    src/HtmlTranslator.cpp 
+    src/StoredFave.cpp 
+    src/ZoomLevelSelector.cpp
+    ${GMIC_PATH}/gmic.cpp
+)
+
+qt5_wrap_ui(gmic_qt_SRCS
+    ui/inoutpanel.ui 
+    ui/multilinetextparameterwidget.ui 
+    ui/progressinfowindow.ui 
+    ui/dialogsettings.ui 
+    ui/progressinfowidget.ui 
+    ui/mainwindow.ui 
+    ui/SearchFieldWidget.ui 
+    ui/headlessprogressdialog.ui 
+    ui/zoomlevelselector.ui
+)    
+
+qt5_create_translation(
+    qmic_qt_QM
+    
+    ${CMAKE_SOURCE_DIR}/translations
+    
+    ${gmic_qt_SRCS}
+    
+    translations/cs.ts
+    translations/de.ts
+    translations/es.ts
+    translations/fr.ts
+    translations/id.ts
+    translations/it.ts
+    translations/nl.ts
+    translations/pl.ts
+    translations/pt.ts
+    translations/ru.ts
+    translations/ua.ts
+    translations/ja.ts
+    translations/zh.ts
+)
+
+install(FILES ${gmic_qt_QM} DESTINATION ${CMAKE_SOURCE_DIR/translations})
+    
+set(gmic_qt_QRC
+    gmic_qt.qrc
+    translations.qrc
+)   
+    
+if (${GMIC_QT_HOST} STREQUAL "gimp")
+
+    find_package(Gimp2 REQUIRED)
+    find_package(Cairo REQUIRED)
+    find_package(GTK2 REQUIRED)
+    include_directories(${GIMP2_INCLUDE_DIRS} ${CAIRO_INCLUDE_DIRS} ${GTK2_INCLUDE_DIRS})
+    
+    set (gmic_qt_SRCS ${gmic_qt_SRCS} src/host_gimp.cpp)
+    add_definitions(-DGMIC_HOST=gimp_qt -DGIMP_DISABLE_DEPRECATED)
+    add_executable(gmic_gimp_qt ${gmic_qt_SRCS} ${gmic_qt_QRC} ${qmic_qt_QM})
+    target_link_libraries(
+        gmic_gimp_qt
+    PRIVATE
+        ${GIMP2_LIBRARIES}
+        ${gmic_qt_LIBRARIES}
+    )
+    
+elseif (${GMIC_QT_HOST} STREQUAL "krita")
+    
+    set (gmic_qt_SRCS ${gmic_qt_SRCS} src/host_krita.cpp)
+    add_definitions(-DGMIC_HOST=krita)
+    add_executable(gmic_krita_qt ${gmic_qt_SRCS} ${gmic_qt_QRC} ${qmic_qt_QM})
+    target_link_libraries(
+        gmic_krita_qt
+    PRIVATE
+        ${gmic_qt_LIBRARIES}
+    )
+        
+elseif (${GMIC_QT_HOST} STREQUAL "none")
+    
+    set (gmic_qt_SRCS ${gmic_qt_SRCS} src/host_none.cpp include/standalone/ImageDialog.h src/standalone/ImageDialog.cpp)
+    add_definitions(-DGMIC_HOST=stantalone)
+    add_executable(gmic_qt ${gmic_qt_SRCS} ${gmic_qt_QRC}  ${qmic_qt_QM})
+        target_link_libraries(
+        gmic_qt
+    PRIVATE
+        ${gmic_qt_LIBRARIES}
+    )
+    
+else()
+    message(FATAL_ERROR "GMIC_QT_HOST is not defined as gimp, krita or none")
+endif()
+
+feature_summary(WHAT ALL FATAL_ON_MISSING_REQUIRED_PACKAGES)

--- a/cmake/modules/COPYING-CMAKE-SCRIPTS
+++ b/cmake/modules/COPYING-CMAKE-SCRIPTS
@@ -1,0 +1,22 @@
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+3. The name of the author may not be used to endorse or promote products 
+   derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/cmake/modules/FindCairo.cmake
+++ b/cmake/modules/FindCairo.cmake
@@ -1,0 +1,62 @@
+# - try to find Cairo
+# Once done this will define
+#
+#  CAIRO_FOUND - system has Cairo
+#  CAIRO_CFLAGS - the Cairo CFlags
+#  CAIRO_INCLUDE_DIRS - the Cairo include directories
+#  CAIRO_LIBRARIES - Link these to use Cairo
+#
+# Copyright (C) 2007, 2010, Pino Toscano, <pino@kde.org>
+#
+# Redistribution and use is allowed according to the terms of the BSD license.
+# For details see the accompanying COPYING-CMAKE-SCRIPTS file.
+
+if(CAIRO_INCLUDE_DIRS AND CAIRO_LIBRARIES)
+
+  # in cache already
+  set(CAIRO_FOUND TRUE)
+
+else(CAIRO_INCLUDE_DIRS AND CAIRO_LIBRARIES)
+
+if(NOT WIN32)
+  # use pkg-config to get the directories and then use these values
+  # in the FIND_PATH() and FIND_LIBRARY() calls
+  find_package(PkgConfig REQUIRED)
+  if(Cairo_FIND_VERSION_COUNT GREATER 0)
+    set(_cairo_version_cmp ">=${Cairo_FIND_VERSION}")
+  endif(Cairo_FIND_VERSION_COUNT GREATER 0)
+  pkg_check_modules(_pc_cairo cairo${_cairo_version_cmp})
+  if(_pc_cairo_FOUND)
+    set(CAIRO_FOUND TRUE)
+  endif(_pc_cairo_FOUND)
+else(NOT WIN32)
+  # assume so, for now
+  set(CAIRO_FOUND TRUE)
+endif(NOT WIN32)
+
+if(CAIRO_FOUND)
+  # set it back as false
+  set(CAIRO_FOUND FALSE)
+
+  find_library(CAIRO_LIBRARY cairo
+               HINTS ${_pc_cairo_LIBRARY_DIRS}
+  )
+  set(CAIRO_LIBRARIES "${CAIRO_LIBRARY}")
+
+  find_path(CAIRO_INCLUDE_DIR cairo.h
+            HINTS ${_pc_cairo_INCLUDE_DIRS}
+            PATH_SUFFIXES cairo
+  )
+  set(CAIRO_INCLUDE_DIRS "${CAIRO_INCLUDE_DIR}")
+
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(Cairo DEFAULT_MSG CAIRO_LIBRARIES CAIRO_INCLUDE_DIRS)
+endif(CAIRO_FOUND)
+
+endif(CAIRO_INCLUDE_DIRS AND CAIRO_LIBRARIES)
+
+mark_as_advanced(
+  CAIRO_CFLAGS
+  CAIRO_INCLUDE_DIRS
+  CAIRO_LIBRARIES
+)

--- a/cmake/modules/FindFFTW3.cmake
+++ b/cmake/modules/FindFFTW3.cmake
@@ -1,0 +1,57 @@
+ # - Try to find the Fftw3 Library
+# Once done this will define
+#
+#  FFTW3_FOUND - system has fftw3
+#  FFTW3_INCLUDE_DIRS - the fftw3 include directories
+#  FFTW3_LIBRARIES - the libraries needed to use fftw3
+# Redistribution and use is allowed according to the terms of the BSD license.
+# For details see the accompanying COPYING-CMAKE-SCRIPTS file.
+#
+if (NOT WIN32)
+include(LibFindMacros)
+libfind_pkg_check_modules(FFTW3_PKGCONF fftw3>=3.2)
+
+find_path(FFTW3_INCLUDE_DIR
+    NAMES fftw3.h
+    HINTS ${FFTW3_PKGCONF_INCLUDE_DIRS} ${FFTW3_PKGCONF_INCLUDEDIR}
+    PATH_SUFFIXES fftw3
+)
+
+find_library(FFTW3_LIBRARY
+    NAMES fftw3
+    HINTS ${FFTW3_PKGCONF_LIBRARY_DIRS} ${FFTW3_PKGCONF_LIBDIR}
+)
+
+set(FFTW3_PROCESS_LIBS FFTW3_LIBRARY)
+set(FFTW3_PROCESS_INCLUDES FFTW3_INCLUDE_DIR)
+libfind_process(FFTW3)
+
+if(FFTW3_FOUND)
+    message(STATUS "FFTW Found Version: " ${FFTW_VERSION})
+endif()
+
+else()
+
+find_path(FFTW3_INCLUDE_DIR
+    NAMES fftw3.h
+)
+
+
+find_library(
+    FFTW3_LIBRARY
+    NAMES libfftw3-3 libfftw3f-3 libfftw3l-3
+    DOC "Libraries to link against for FFT Support")
+
+if (FFTW3_LIBRARY)
+    set(FFTW3_LIBRARY_DIR ${FFTW3_LIBRARY})
+endif()
+
+set (FFTW3_LIBRARIES ${FFTW3_LIBRARY})
+
+if(FFTW3_INCLUDE_DIR AND FFTW3_LIBRARY_DIR)
+ set (FFTW3_FOUND true)
+ message(STATUS "Correctly found FFTW3")
+else()
+  message(STATUS "Could not find FFTW3")
+endif()
+endif()

--- a/cmake/modules/FindGimp2.cmake
+++ b/cmake/modules/FindGimp2.cmake
@@ -1,0 +1,59 @@
+# - Try to find the libgimp-2.0 Library
+# Once done this will define
+#
+#  GIMP2_FOUND - system has gimp
+#  GIMP2_INCLUDE_DIRS - the gimp include directories
+#  GIMP2_LIBRARIES - the libraries needed to use gimp
+#
+# Redistribution and use is allowed according to the terms of the BSD license.
+
+if (NOT WIN32)
+    include(LibFindMacros)
+    libfind_pkg_check_modules(GIMP2_PKGCONF gimp-2.0)
+
+    find_path(GIMP2_INCLUDE_DIR
+        NAMES libgimp/gimp.h
+        HINTS ${GIMP2_PKGCONF_INCLUDE_DIRS} ${GIMP2_PKGCONF_INCLUDEDIR}
+    )
+
+    # we want the toplevel include directory
+    string(REPLACE "libgimp" "" GIMP2_INCLUDE_DIR_STRIPPED ${GIMP2_INCLUDE_DIR})
+    
+    find_library(GIMP2_LIBRARY
+        NAMES gimp-2.0
+        HINTS ${GIMP2_PKGCONF_LIBRARY_DIRS} ${GIMP2_PKGCONF_LIBDIR}
+    )
+
+    set(GIMP2_PROCESS_LIBS GIMP2_LIBRARY)
+    set(GIMP2_PROCESS_INCLUDES GIMP2_INCLUDE_DIR_STRIPPED)
+    libfind_process(GIMP2)
+
+    if(GIMP2_FOUND)
+        message(STATUS "GIMP Found Version: " ${GIMP2_VERSION})
+    endif()
+
+else()
+
+    find_path(GIMP2_INCLUDE_DIR
+        NAMES gimp.h
+    )
+
+
+    find_library(
+        GIMP2_LIBRARY
+        NAMES libgimp-2.0
+        DOC "Libraries to link against for Gimp Support")
+
+    if (GIMP2_LIBRARY)
+        set(GIMP2_LIBRARY_DIR ${GIMP2_LIBRARY})
+    endif()
+
+    set (GIMP2_LIBRARIES ${GIMP2_LIBRARY})
+
+    if(GIMP2_INCLUDE_DIR AND GIMP2_LIBRARY_DIR)
+        set (GIMP2_FOUND true)
+        message(STATUS "Correctly found GIMP2")
+    else()
+        message(STATUS "Could not find GIMP2")
+    endif()
+endif()

--- a/cmake/modules/LibFindMacros.cmake
+++ b/cmake/modules/LibFindMacros.cmake
@@ -1,0 +1,112 @@
+# Version 1.0 (2013-04-12)
+# Public Domain, originally written by Lasse Kärkkäinen <tronic@zi.fi>
+# Published at http://www.cmake.org/Wiki/CMake:How_To_Find_Libraries
+
+# If you improve the script, please modify the forementioned wiki page because
+# I no longer maintain my scripts (hosted as static files at zi.fi). Feel free
+# to remove this entire header if you use real version control instead.
+
+# Changelog:
+# 2013-04-12  Added version number (1.0) and this header, no other changes
+# 2009-10-08  Originally published
+
+
+# Works the same as find_package, but forwards the "REQUIRED" and "QUIET" arguments
+# used for the current package. For this to work, the first parameter must be the
+# prefix of the current package, then the prefix of the new package etc, which are
+# passed to find_package.
+macro (libfind_package PREFIX)
+  set (LIBFIND_PACKAGE_ARGS ${ARGN})
+  if (${PREFIX}_FIND_QUIETLY)
+    set (LIBFIND_PACKAGE_ARGS ${LIBFIND_PACKAGE_ARGS} QUIET)
+  endif ()
+  if (${PREFIX}_FIND_REQUIRED)
+    set (LIBFIND_PACKAGE_ARGS ${LIBFIND_PACKAGE_ARGS} REQUIRED)
+  endif ()
+  find_package(${LIBFIND_PACKAGE_ARGS})
+endmacro (libfind_package)
+
+# CMake developers made the UsePkgConfig system deprecated in the same release (2.6)
+# where they added pkg_check_modules. Consequently I need to support both in my scripts
+# to avoid those deprecated warnings. Here's a helper that does just that.
+# Works identically to pkg_check_modules, except that no checks are needed prior to use.
+macro (libfind_pkg_check_modules PREFIX PKGNAME)
+  if (${CMAKE_MAJOR_VERSION} EQUAL 2 AND ${CMAKE_MINOR_VERSION} EQUAL 4)
+    include(UsePkgConfig)
+    pkgconfig(${PKGNAME} ${PREFIX}_INCLUDE_DIRS ${PREFIX}_LIBRARY_DIRS ${PREFIX}_LDFLAGS ${PREFIX}_CFLAGS)
+  else ()
+    find_package(PkgConfig)
+    if (PKG_CONFIG_FOUND)
+      pkg_check_modules(${PREFIX} QUIET ${PKGNAME})
+    endif ()
+  endif ()
+endmacro (libfind_pkg_check_modules)
+
+# Do the final processing once the paths have been detected.
+# If include dirs are needed, ${PREFIX}_PROCESS_INCLUDES should be set to contain
+# all the variables, each of which contain one include directory.
+# Ditto for ${PREFIX}_PROCESS_LIBS and library files.
+# Will set ${PREFIX}_FOUND, ${PREFIX}_INCLUDE_DIRS and ${PREFIX}_LIBRARIES.
+# Also handles errors in case library detection was required, etc.
+macro (libfind_process PREFIX)
+  # Skip processing if already processed during this run
+  if (NOT ${PREFIX}_FOUND)
+    # Start with the assumption that the library was found
+    set (${PREFIX}_FOUND TRUE)
+
+    # Process all includes and set _FOUND to false if any are missing
+    foreach (i ${${PREFIX}_PROCESS_INCLUDES})
+      if (${i})
+        set (${PREFIX}_INCLUDE_DIRS ${${PREFIX}_INCLUDE_DIRS} ${${i}})
+        mark_as_advanced(${i})
+      else ()
+        set (${PREFIX}_FOUND FALSE)
+      endif ()
+    endforeach (i)
+
+    # Process all libraries and set _FOUND to false if any are missing
+    foreach (i ${${PREFIX}_PROCESS_LIBS})
+      if (${i})
+        set (${PREFIX}_LIBRARIES ${${PREFIX}_LIBRARIES} ${${i}})
+        mark_as_advanced(${i})
+      else ()
+        set (${PREFIX}_FOUND FALSE)
+      endif ()
+    endforeach (i)
+
+    # Print message and/or exit on fatal error
+    if (${PREFIX}_FOUND)
+      if (NOT ${PREFIX}_FIND_QUIETLY)
+        message (STATUS "Found ${PREFIX} ${${PREFIX}_VERSION}")
+      endif ()
+    else ()
+      if (${PREFIX}_FIND_REQUIRED)
+        foreach (i ${${PREFIX}_PROCESS_INCLUDES} ${${PREFIX}_PROCESS_LIBS})
+          message("${i}=${${i}}")
+        endforeach (i)
+        message (FATAL_ERROR "Required library ${PREFIX} NOT FOUND.\nInstall the library (dev version) and try again. If the library is already installed, use ccmake to set the missing variables manually.")
+      endif ()
+    endif ()
+  endif ()
+endmacro (libfind_process)
+
+macro(libfind_library PREFIX basename)
+  set(TMP "")
+  if(MSVC80)
+    set(TMP -vc80)
+  endif()
+  if(MSVC90)
+    set(TMP -vc90)
+  endif()
+  set(${PREFIX}_LIBNAMES ${basename}${TMP})
+  if(${ARGC} GREATER 2)
+    set(${PREFIX}_LIBNAMES ${basename}${TMP}-${ARGV2})
+    string(REGEX REPLACE "\\." "_" TMP ${${PREFIX}_LIBNAMES})
+    set(${PREFIX}_LIBNAMES ${${PREFIX}_LIBNAMES} ${TMP})
+  endif()
+  find_library(${PREFIX}_LIBRARY
+    NAMES ${${PREFIX}_LIBNAMES}
+    PATHS ${${PREFIX}_PKGCONF_LIBRARY_DIRS}
+  )
+endmacro(libfind_library)
+


### PR DESCRIPTION
This build system can build gmic_qt (gimp, krita and host) on Windows (tested with mingw-64), Linux (gcc 4.8.5) and OSX (clang, 10.9 sdk), if the dependencies are present. 

Note: it's not perfect yet, I still need to figure out why cmake on OSX doesn't set the rpath correctly. It's possible that this cannot be done from cmake and must be done in a deploy script.

The following CMake variables can be used:
    
    GMIC_QT_HOST = {krita|gimp|none}
    GMIC_PATH: the path to the gmic checkout or release
    PRELEASE: to indicate that this isn't a final release