### PR TITLE
Enable 'Ofast' optimizations.

### DIFF
--- a/gmic_qt.pro
+++ b/gmic_qt.pro
@@ -387,7 +387,7 @@ translations/zh_tw.ts
 
 # PRE_TARGETDEPS +=
 
-QMAKE_CXXFLAGS_RELEASE += -O3 -s
+QMAKE_CXXFLAGS_RELEASE += -Ofast -s # -O3 -s
 QMAKE_LFLAGS_RELEASE += -s
 QMAKE_CXXFLAGS_DEBUG += -Dcimg_verbosity=3
 


### PR DESCRIPTION
Changes in the CImg Library (https://github.com/dtschump/CImg/commit/913065c6d61d0faeed895498e1c611b359a46bca) makes '-Ofast' a working optimization flag for compiling G'MIC.