### PR TITLE
Fix translation files path.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -427,26 +427,8 @@ qt5_wrap_ui(gmic_qt_SRCS
   ui/zoomlevelselector.ui
 )
 
-# qt5_create_translation(
-#     qmic_qt_QM
-#     ${CMAKE_SOURCE_DIR}/translations
-#     ${gmic_qt_SRCS}
-#     translations/cs.ts
-#     translations/de.ts
-#     translations/es.ts
-#     translations/fr.ts
-#     translations/id.ts
-#     translations/it.ts
-#     translations/nl.ts
-#     translations/pl.ts
-#     translations/pt.ts
-#     translations/ru.ts
-#     translations/ua.ts
-#     translations/ja.ts
-#     translations/zh.ts
-# )
+set(gmic_translation_files
 
-qt5_add_translation(gmic_qt_QM
     translations/cs.ts
     translations/de.ts
     translations/es.ts
@@ -460,6 +442,19 @@ qt5_add_translation(gmic_qt_QM
     translations/ua.ts
     translations/ja.ts
     translations/zh.ts
+)
+
+set_source_files_properties(${gmic_translation_files} PROPERTIES OUTPUT_LOCATION translations)
+
+# qt5_create_translation(
+#     qmic_qt_QM
+#     ${CMAKE_SOURCE_DIR}/translations
+#     ${gmic_qt_SRCS}
+#     ${gmic_translation_files}
+# )
+
+qt5_add_translation(gmic_qt_QM
+    ${gmic_translation_files}
   )
 
 install(FILES ${gmic_qt_QM} DESTINATION ${CMAKE_SOURCE_DIR}/translations)


### PR DESCRIPTION
Without setting property on the files, it was trying to find the
generated files on the root of the repository at install time.

After building gmic-qt and running `make install` (which doesn't seem to do much anyway!), I had this error:

```
$ make install
[  1%] Automatic MOC for target gmic_gimp_qt
[  1%] Built target gmic_gimp_qt_autogen
[100%] Built target gmic_gimp_qt
Install the project...
-- Install configuration: "Release"
CMake Error at cmake_install.cmake:49 (file):
  file INSTALL cannot find "/home/jehan/dev/build/gmic-qt/cs.qm".


make: *** [Makefile:118: install] Error 1
```

It seems that it expects the `qm` files to be at the root. I added some property to the file list to make it end without error (as inspired by [this](https://stackoverflow.com/questions/44782914/cmake-qt5-add-translation-how-to-specify-the-output-path?rq=1)).

Of course, I realize now that `make install` actually does nothing useful (I first thought it would try to install gmic-qt as a GIMP system plug-in on the set prefix), but it's still better to have the command successfully end. :-)