### PR TITLE
Detect full plug-in path under MacOS

### DIFF
--- a/src/gmic_qt.cpp
+++ b/src/gmic_qt.cpp
@@ -43,6 +43,11 @@
 #include "Widgets/LanguageSelectionWidget.h"
 #include "Widgets/ProgressInfoWindow.h"
 #include "gmic.h"
+#ifdef _IS_MACOS_
+#include <stdlib.h>
+#include <libgen.h>
+#include <mach-o/dyld.h>
+#endif
 
 namespace GmicQt
 {
@@ -62,11 +67,41 @@ int launchPlugin()
   TIMING;
   int dummy_argc = 1;
   char dummy_app_name[] = GMIC_QT_APPLICATION_NAME;
-  char * dummy_argv[1] = {dummy_app_name};
-
 #ifdef _IS_WINDOWS_
   SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX | SEM_NOOPENFILEERRORBOX);
 #endif
+
+  char* fullexname = NULL;
+#ifdef _IS_MACOS_
+  {
+    char exname[2048] = {0};
+    // get the path where the executable is stored
+    uint32_t size = sizeof(exname);
+    if (_NSGetExecutablePath(exname, &size) == 0) {
+      printf("executable path is %s\n", exname);
+      fullexname = realpath(exname,NULL);
+      printf("full executable name is %s\n", fullexname);
+      if( fullexname ) {
+        char* fullpath = dirname(fullexname);
+        printf("full executable path is %s\n", fullpath);
+        if( fullpath ) {
+          char pluginpath[2048] = {0};
+          strncpy( pluginpath, fullpath, 2047);
+          strncat( pluginpath, "/GMIC/plugins/:", 2047);
+          char* envpath = getenv("QT_PLUGIN_PATH");
+          if( envpath ) strncat( pluginpath, envpath, 2047);
+          printf("plugins path is %s\n", pluginpath);
+          setenv("QT_PLUGIN_PATH", pluginpath, 1);
+        }
+      }
+    } else
+      printf("buffer too small; need size %u\n", size);
+
+    setenv("QT_DEBUG_PLUGINS", "1", 1);
+  }
+#endif
+  if( !fullexname ) fullexname = dummy_app_name;
+  char * dummy_argv[1] = {fullexname};
 
   QApplication app(dummy_argc, dummy_argv);
   app.setWindowIcon(QIcon(":resources/gmic_hat.png"));


### PR DESCRIPTION
The full path to the plug-in executable is
determined using the _NSGetExecutablePath() function.

The GMIC/plugins/ sub-folder is then added to the
QT_PLUGIN_PATH environment variable, so that Qt plugins
are searched relative to the emplacement of the
gmic_gimp_qt executable