### PR TITLE
Minor cleanup in the Paint.NET host plugin

### DIFF
--- a/src/Host/PaintDotNet/host_paintdotnet.cpp
+++ b/src/Host/PaintDotNet/host_paintdotnet.cpp
@@ -32,160 +32,160 @@
 
 namespace host_paintdotnet
 {
-	QVector<QImage> layerImages;
-	
-	QString outputImagePath;
+    QVector<QImage> layerImages;
+
+    QString outputImagePath;
 }
 
 namespace GmicQt
 {
-	const QString HostApplicationName = QString("Paint.NET");
-	const char * HostApplicationShortname = GMIC_QT_XSTRINGIFY(GMIC_HOST);
-        const bool DarkThemeIsDefault = false;
+    const QString HostApplicationName = QString("Paint.NET");
+    const char * HostApplicationShortname = GMIC_QT_XSTRINGIFY(GMIC_HOST);
+    const bool DarkThemeIsDefault = false;
 }
 
 void gmic_qt_get_layers_extent(int * width, int * height, GmicQt::InputMode)
 {
-	// Paint.NET layers are all the same size.
-	const QImage firstLayer = host_paintdotnet::layerImages.at(0);
-	
-	*width = firstLayer.width();
-	*height = firstLayer.height();
+    // Paint.NET layers are all the same size.
+    const QImage firstLayer = host_paintdotnet::layerImages.at(0);
+
+    *width = firstLayer.width();
+    *height = firstLayer.height();
 }
 
 void gmic_qt_get_cropped_images(gmic_list<float> & images, gmic_list<char> & imageNames, double x, double y, double width, double height, GmicQt::InputMode mode)
 {
-	if (mode == GmicQt::NoInput)
-	{
-		images.assign();
-		imageNames.assign();
-		return;
-	}
-	
-	const bool entireImage = x < 0 && y < 0 && width < 0 && height < 0;
-	if (entireImage)
-	{
-		x = 0.0;
-		y = 0.0;
-		width = 1.0;
-		height = 1.0;
-	}
+    if (mode == GmicQt::NoInput)
+    {
+        images.assign();
+        imageNames.assign();
+        return;
+    }
 
-	const int layerCount = host_paintdotnet::layerImages.count();
-	
-	images.assign(layerCount);
-	imageNames.assign(layerCount);
-	
-	for (int i = 0; i < layerCount; i++)
-	{
-		QString layerName = QString("pos(0,0),name(layer%1)").arg(i);
-		QByteArray layerNameBytes = layerName.toUtf8();
-		gmic_image<char>::string(layerNameBytes.constData()).move_to(imageNames[i]);
-	}	
-	
-	int imageWidth;
-	int imageHeight;
-	gmic_qt_get_layers_extent(&imageWidth, &imageHeight, mode);
+    const bool entireImage = x < 0 && y < 0 && width < 0 && height < 0;
+    if (entireImage)
+    {
+        x = 0.0;
+        y = 0.0;
+        width = 1.0;
+        height = 1.0;
+    }
 
-	const int ix = entireImage ? 0 : static_cast<int>(std::floor(x * imageWidth));
-	const int iy = entireImage ? 0 : static_cast<int>(std::floor(y * imageHeight));
-	const int iw = entireImage ? imageWidth : std::min(imageWidth - ix, static_cast<int>(1 + std::ceil(width * imageWidth)));
-	const int ih = entireImage ? imageHeight : std::min(imageHeight - iy, static_cast<int>(1 + std::ceil(height * imageHeight)));
-		
-	for (int i = 0; i < layerCount; i++)
-	{			
-		ImageConverter::convert(host_paintdotnet::layerImages.at(i).copy(ix, iy, iw, ih), images[i]);
-	}
+    const int layerCount = host_paintdotnet::layerImages.count();
+
+    images.assign(layerCount);
+    imageNames.assign(layerCount);
+
+    for (int i = 0; i < layerCount; i++)
+    {
+        QString layerName = QString("pos(0,0),name(layer%1)").arg(i);
+        QByteArray layerNameBytes = layerName.toUtf8();
+        gmic_image<char>::string(layerNameBytes.constData()).move_to(imageNames[i]);
+    }
+
+    int imageWidth;
+    int imageHeight;
+    gmic_qt_get_layers_extent(&imageWidth, &imageHeight, mode);
+
+    const int ix = entireImage ? 0 : static_cast<int>(std::floor(x * imageWidth));
+    const int iy = entireImage ? 0 : static_cast<int>(std::floor(y * imageHeight));
+    const int iw = entireImage ? imageWidth : std::min(imageWidth - ix, static_cast<int>(1 + std::ceil(width * imageWidth)));
+    const int ih = entireImage ? imageHeight : std::min(imageHeight - iy, static_cast<int>(1 + std::ceil(height * imageHeight)));
+
+    for (int i = 0; i < layerCount; i++)
+    {
+        ImageConverter::convert(host_paintdotnet::layerImages.at(i).copy(ix, iy, iw, ih), images[i]);
+    }
 }
 
 void gmic_qt_output_images(gmic_list<float> & images, const gmic_list<char> & imageNames, GmicQt::OutputMode mode, const char * verboseLayersLabel)
 {
-	unused(imageNames);
-	unused(mode);
-	unused(verboseLayersLabel);
-	
-	if (images.size() > 0)
-	{
-		QImage outputImage;
+    unused(imageNames);
+    unused(mode);
+    unused(verboseLayersLabel);
 
-		ImageConverter::convert(images[0], outputImage);
+    if (images.size() > 0)
+    {
+        QImage outputImage;
 
-		outputImage.save(host_paintdotnet::outputImagePath);
-	}
+        ImageConverter::convert(images[0], outputImage);
+
+        outputImage.save(host_paintdotnet::outputImagePath);
+    }
 }
 
 void gmic_qt_apply_color_profile(cimg_library::CImg<gmic_pixel_type> & images)
 {
-	unused(images);
+    unused(images);
 }
 
 void gmic_qt_show_message(const char * message)
 {
-	unused(message);	
+    unused(message);
 }
 
 int main(int argc, char *argv[])
 {
-	QString firstLayerImagePath;
-	QString secondLayerImagePath;
-	bool useLastParameters = false;
+    QString firstLayerImagePath;
+    QString secondLayerImagePath;
+    bool useLastParameters = false;
 
-	if (argc >= 4)
-	{
-		firstLayerImagePath = argv[1];
-		secondLayerImagePath = argv[2];
-		host_paintdotnet::outputImagePath = argv[3];
-		if (argc == 5)
-		{
-			useLastParameters = strcmp(argv[4], "reapply") == 0;
-		}
-	}
-	else
-	{
-		std::cerr << "Usage: gmic_paintdotnet_qt first_image second_image output_image\n";
-		return 1;
-	}
+    if (argc >= 4)
+    {
+        firstLayerImagePath = argv[1];
+        secondLayerImagePath = argv[2];
+        host_paintdotnet::outputImagePath = argv[3];
+        if (argc == 5)
+        {
+            useLastParameters = strcmp(argv[4], "reapply") == 0;
+        }
+    }
+    else
+    {
+        std::cerr << "Usage: gmic_paintdotnet_qt first_image second_image output_image\n";
+        return 1;
+    }
 
-	if (firstLayerImagePath.isEmpty())
-	{
-		std::cerr << "Input filename is an empty string.\n";
-		return 1;
-	}
+    if (firstLayerImagePath.isEmpty())
+    {
+        std::cerr << "Input filename is an empty string.\n";
+        return 1;
+    }
 
-	if (host_paintdotnet::outputImagePath.isEmpty())
-	{
-		std::cerr << "Output filename is an empty string.\n";
-		return 1;
-	}
-	
-	QImage firstLayer(firstLayerImagePath);
-	
-	if (!firstLayer.isNull())
-	{
-		host_paintdotnet::layerImages.append(firstLayer.convertToFormat(QImage::Format_ARGB32));			
-		
-		// Paint.NET can optionally pass a second image for the filters that require two layers.
-		
-		if (!secondLayerImagePath.isEmpty())
-		{		
-			QImage secondLayer(secondLayerImagePath);
+    if (host_paintdotnet::outputImagePath.isEmpty())
+    {
+        std::cerr << "Output filename is an empty string.\n";
+        return 1;
+    }
 
-			if (!secondLayer.isNull())
-			{
-				host_paintdotnet::layerImages.append(secondLayer.convertToFormat(QImage::Format_ARGB32));
-			}			
-		}
-		
-		if (useLastParameters)
-		{
-			return launchPluginHeadlessUsingLastParameters();
-		}
-		else
-		{
-			return launchPlugin();
-		}
-	}
+    QImage firstLayer(firstLayerImagePath);
 
-	std::cerr << "Unable to load the input image" << firstLayerImagePath.toLocal8Bit().constData() << "\n";
-	return 1;
+    if (!firstLayer.isNull())
+    {
+        host_paintdotnet::layerImages.append(firstLayer.convertToFormat(QImage::Format_ARGB32));
+
+        // Paint.NET can optionally pass a second image for the filters that require two layers.
+
+        if (!secondLayerImagePath.isEmpty())
+        {
+            QImage secondLayer(secondLayerImagePath);
+
+            if (!secondLayer.isNull())
+            {
+                host_paintdotnet::layerImages.append(secondLayer.convertToFormat(QImage::Format_ARGB32));
+            }
+        }
+
+        if (useLastParameters)
+        {
+            return launchPluginHeadlessUsingLastParameters();
+        }
+        else
+        {
+            return launchPlugin();
+        }
+    }
+
+    std::cerr << "Unable to load the input image" << firstLayerImagePath.toLocal8Bit().constData() << "\n";
+    return 1;
 }


### PR DESCRIPTION
Use spaces instead of tabs for indentation and remove some extra white-space.