### PR TITLE
proposing github sponsor button on home page

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+custom: https://libreart.info/en/projects/gmic


### PR DESCRIPTION
Please check the sponsorship checkbox in the repository settings.
Already applied on dstchump/gmic and myselfhimself/gmic-py