### PR TITLE
CMakeLists: don't hardcode pkg-config and don't use gimptool anymore.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ message(STATUS "Using CMake version: ${CMAKE_VERSION}")
 cmake_minimum_required(VERSION 3.1.0 FATAL_ERROR)
 LIST (APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/modules")
 include(FeatureSummary)
+include(FindPkgConfig)
 
 set(CMAKE_CXX_STANDARD 11)
 add_definitions(-Dcimg_use_cpp11=1)
@@ -515,9 +516,9 @@ set(gmic_qt_QRC
 
 if (${GMIC_QT_HOST} STREQUAL "gimp")
 
-    execute_process(COMMAND gimptool-2.0 --libs-noui OUTPUT_VARIABLE GIMP2_LIBRARIES OUTPUT_STRIP_TRAILING_WHITESPACE)
-    execute_process(COMMAND gimptool-2.0 --cflags-noui OUTPUT_VARIABLE GIMP2_INCLUDE_DIRS OUTPUT_STRIP_TRAILING_WHITESPACE)
-    execute_process(COMMAND pkg-config gimp-2.0 --define-variable=prefix=${CMAKE_INSTALL_PREFIX} --variable gimplibdir OUTPUT_VARIABLE GIMP2_PKGLIBDIR OUTPUT_STRIP_TRAILING_WHITESPACE)
+    execute_process(COMMAND ${PKG_CONFIG_EXECUTABLE} --libs gimp-2.0 OUTPUT_VARIABLE GIMP2_LIBRARIES OUTPUT_STRIP_TRAILING_WHITESPACE)
+    execute_process(COMMAND ${PKG_CONFIG_EXECUTABLE} --cflags gimp-2.0 OUTPUT_VARIABLE GIMP2_INCLUDE_DIRS OUTPUT_STRIP_TRAILING_WHITESPACE)
+    execute_process(COMMAND ${PKG_CONFIG_EXECUTABLE} gimp-2.0 --define-variable=prefix=${CMAKE_INSTALL_PREFIX} --variable gimplibdir OUTPUT_VARIABLE GIMP2_PKGLIBDIR OUTPUT_STRIP_TRAILING_WHITESPACE)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GIMP2_INCLUDE_DIRS}")
 
     set (gmic_qt_SRCS ${gmic_qt_SRCS} src/Host/Gimp/host_gimp.cpp)


### PR DESCRIPTION
Cf. our discussion on Twitter. This is the only change I had to do on the build system to be able to cross-build G'MIC for Windows.

There is another issue with the `CMAKE_AUTOMOC` tool but for now I could at least make the build work with Wine and binfmt_misc, which worked fine anyway. Eventually though if I can understand what `moc` does, it would be better to run a native binary at build time.

------------------------------------------------------------------------------------------

Hardcoding `pkg-config` will work only for native builds. If you want to
cross-compile, you need to search for the appropriate tools, which is
what FindPkgConfig module does. Then you can use PKG_CONFIG_EXECUTABLE
variable which will be set according to your toolchain rules.

Also old-style binary config tools are not a good idea as they are not
very cross-compilation friendly (to do it right, we would have to
generate variants per (host, target) couple). Instead pkg-config is the
right process as it works well without having to run non-native
binaries. I am actually considering removing gimptool from GIMP
eventually (and document the generic pkg-config process instead).

Running `gimptool-2.0 --libs-noui` and `--cflags-noui` is the
equivalent to run `pkg-config --libs` (`--cflags` respectively) on
`gimp-2.0`. So let's just replace by these commands.