### PR TITLE
Fix compilation issues with the latest G'MIC API changes.

### DIFF
--- a/src/FilterSyncRunner.cpp
+++ b/src/FilterSyncRunner.cpp
@@ -152,7 +152,7 @@ void FilterSyncRunner::run()
     if (_messageMode > GmicQt::Quiet) {
       Logger::log(fullCommandLine, _logSuffix, true);
     }
-    gmic gmicInstance(_environment.isEmpty() ? nullptr : QString("%1").arg(_environment).toLocal8Bit().constData(), GmicStdLib::Array.constData(), true);
+    gmic gmicInstance(_environment.isEmpty() ? nullptr : QString("%1").arg(_environment).toLocal8Bit().constData(), GmicStdLib::Array.constData(), true, 0, 0, 0.f);
     gmicInstance.set_variable("_host", GmicQt::HostApplicationShortname, '=');
     gmicInstance.set_variable("_tk", "qt", '=');
     gmicInstance.run(fullCommandLine.toLocal8Bit().constData(), *_images, *_imageNames, &_gmicProgress, &_gmicAbort);

--- a/src/FilterThread.cpp
+++ b/src/FilterThread.cpp
@@ -214,7 +214,7 @@ void FilterThread::run()
     if (_messageMode > GmicQt::Quiet) {
       Logger::log(fullCommandLine, _logSuffix, true);
     }
-    gmic gmicInstance(_environment.isEmpty() ? nullptr : QString("%1").arg(_environment).toLocal8Bit().constData(), GmicStdLib::Array.constData(), true);
+    gmic gmicInstance(_environment.isEmpty() ? nullptr : QString("%1").arg(_environment).toLocal8Bit().constData(), GmicStdLib::Array.constData(), true, 0, 0, 0.0f);
     gmicInstance.set_variable("_host", GmicQt::HostApplicationShortname, '=');
     gmicInstance.set_variable("_tk", "qt", '=');
     gmicInstance.run(fullCommandLine.toLocal8Bit().constData(), *_images, *_imageNames, &_gmicProgress, &_gmicAbort);


### PR DESCRIPTION
I had to make some slight modifications to the definition of the `gmic()` constructor in `gmic.h` , due to default template value not supported for functions, in MSVC2012.
The patch here fixes compilation issues of G'MIC-Qt regarding these changes.