### PR TITLE
Remove an unused variable in CopyTileToGmicImage16Planar

### DIFF
--- a/src/Host/8bf/host_8bf.cpp
+++ b/src/Host/8bf/host_8bf.cpp
@@ -510,7 +510,6 @@ namespace
         const QVector<float>& sixteenBitToEightBitLUT)
     {
         const int imageWidth = image.width();
-        const int imageHeight = image.height();
 
         float* plane = image.data(0, 0, 0, channelIndex);
 


### PR DESCRIPTION
Fixes #118