### PR TITLE
Add MSVC compatibility and other bits

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,10 +29,10 @@ else()
   message("Building for target host application: " ${GMIC_QT_HOST})
 endif()
 
-if(EXISTS "../src/gmic.cpp")
-  set (GMIC_PATH "../src" CACHE STRING "Define the path to the gmic headers")
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/../src/gmic.cpp")
+  set (GMIC_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../src" CACHE STRING "Define the path to the gmic headers")
 else()
-  set (GMIC_PATH "../gmic/src" CACHE STRING "Define the path to the gmic headers")
+  set (GMIC_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../gmic/src" CACHE STRING "Define the path to the gmic headers")
 endif()
 
 message("G'MIC path: " ${GMIC_PATH})
@@ -44,15 +44,20 @@ set (GMIC_LIB_PATH "${GMIC_PATH}" CACHE STRING "Define the path to the GMIC shar
 option(ENABLE_ASAN "Enable -fsanitize=address (if debug build)" ON)
 option(ENABLE_FFTW3 "Enable FFTW3 library support" ON)
 
-option(ENABLE_LTO "Enable -flto (Link Time Optimizer) on gcc and clang" ON)
+option(ENABLE_LTO "Enable Link Time Optimizer" ON)
 
-if (WIN32)
-    message("LTO is disabled (windows platform)")
+if (MSVC)
+  option(ENABLE_CFG "Enable Control Flow Guard (MSVC)" ON)
+  add_definitions(-D__PRETTY_FUNCTION__=__FUNCSIG__)
+endif()
+
+if (WIN32 AND NOT MSVC)
+    message("LTO is disabled (windows platform, not MSVC)")
     set(ENABLE_LTO OFF)
 endif()
 
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")
-    set(ENABLE_LTO OFF)
+    set(ENABLE_LTO OFF FORCE)
 endif()
 
 
@@ -122,6 +127,11 @@ endif()
 
 
 # Required packages
+
+#
+# Threads
+#
+find_package(Threads REQUIRED)
 
 #
 # Qt5
@@ -203,10 +213,33 @@ endif()
 # LTO option
 #
 
-if (ENABLE_LTO AND (CMAKE_COMPILER_IS_GNUCC OR (CMAKE_CSS_COMPILER_IS STREQUAL "Clang")))
+if (ENABLE_LTO)
     message("Link Time Optimizer enabled")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -flto")
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -flto")
+    if (MSVC)
+      string(REPLACE "INCREMENTAL" "INCREMENTAL:NO" CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO "${CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO}")
+      string(REPLACE "INCREMENTAL" "INCREMENTAL:NO" CMAKE_SHARED_LINKER_FLAGS_RELWITHDEBINFO "${CMAKE_SHARED_LINKER_FLAGS_RELWITHDEBINFO}")
+      string(REPLACE "INCREMENTAL" "INCREMENTAL:NO" CMAKE_MODULE_LINKER_FLAGS_RELWITHDEBINFO "${CMAKE_MODULE_LINKER_FLAGS_RELWITHDEBINFO}")
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /GL")
+      set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /LTCG")
+      set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /LTCG")
+      set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /LTCG")
+    else()
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -flto")
+      set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -flto")
+    endif()
+endif()
+
+#
+# Enable CFG
+#
+if (MSVC)
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /STACK:4194304")
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /STACK:4194304")
+    set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} /STACK:4194304")
+    if (ENABLE_CFG)
+        add_compile_options(/guard:CF)
+        add_link_options(/GUARD:CF)
+    endif()
 endif()
 
 #
@@ -265,9 +298,13 @@ if (WIN32)
     add_definitions(-Dcimg_display=2)
     add_definitions(-DPSAPI_VERSION=1)
     add_definitions(-D_IS_WINDOWS_)
+    if (MSVC)
+      add_definitions(-D_CRT_SECURE_NO_WARNINGS)
+      add_compile_options(/wd4267)
+    endif()
     set(gmic_qt_LIBRARIES
         ${gmic_qt_LIBRARIES}
-        pthread psapi gdi32
+        Threads::Threads psapi gdi32
     )
 endif()
 
@@ -282,19 +319,30 @@ if (CMAKE_BUILD_TYPE STREQUAL "Debug")
     endif(ENABLE_ASAN)
 elseif (CMAKE_BUILD_TYPE STREQUAL "Release")
     add_definitions(-DQT_NO_DEBUG_OUTPUT)
-    string(REPLACE "-O2" "" CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
-    string(REPLACE "-O3" "" CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
-    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -Ofast")
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -s")
-    if (WIN32)
+    if (MSVC)
+      set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /fp:fast /Oi")
+    else()
+      string(REPLACE "-O2" "" CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
+      string(REPLACE "-O3" "" CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
+      set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -Ofast")
+    endif()
+    if (NOT MSVC)
+      set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -s")
+    endif()
+    if (WIN32 AND NOT MSVC)
       set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -mwindows")
     endif()
 elseif (CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
     add_definitions(-DQT_NO_DEBUG_OUTPUT)
-    string(REPLACE "-O2" "" CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
-    string(REPLACE "-O3" "" CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
-    set_source_files_properties(${GMIC_PATH}/gmic.cpp PROPERTIES COMPILE_FLAGS "-Ofast")
-    set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -O2")
+    if(MSVC)
+      string(REPLACE "Ob1" "Ob2" CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
+      set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} /fp:fast /Oi")
+    else()
+      string(REPLACE "-O2" "" CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
+      string(REPLACE "-O3" "" CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
+      set_source_files_properties(${GMIC_PATH}/gmic.cpp PROPERTIES COMPILE_FLAGS "-Ofast")
+      set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -O2")
+    endif()
 else()
     message(FATAL_ERROR "Build type not recognized (${CMAKE_BUILD_TYPE})")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,14 +171,29 @@ include_directories(SYSTEM ${ZLIB_INCLUDE_DIRS} )
 #
 # FFTW3
 #
-find_package(FFTW3 REQUIRED)
-add_definitions(-Dcimg_use_fftw3 )
-include_directories(${FFTW3_INCLUDE_DIR})
-find_library(FFTW3_THREADS_LIB fftw3_threads PATHS ${FFTW3_LIBRARY_DIRS})
-if(FFTW3_THREADS_LIB STREQUAL "FFTW3_THREADS_LIB-NOTFOUND")
+if (ENABLE_FFTW3)
+  find_package(FFTW3 REQUIRED)
+  add_definitions(-Dcimg_use_fftw3 )
+  include_directories(${FFTW3_INCLUDE_DIR})
+
+  # Detect 
+  include(CheckCXXSourceCompiles)
+  set(CMAKE_REQUIRED_INCLUDES ${FFTW3_INCLUDE_DIR})
+  set(CMAKE_REQUIRED_LIBRARIES ${FFTW3_LIBRARIES})
+  check_cxx_source_compiles("
+      #include <fftw3.h>
+
+      int main() {
+          fftw_init_threads();
+      }
+  " HAVE_FFTW3_THREADS)
+
+  if(HAVE_FFTW3_THREADS)
+    message(STATUS "FFTW threads Found")
+    list(APPEND EXTRA_LIBRARIES ${FFTW3_THREADS_LIBRARIES})
+  else()
     add_definitions(-Dcimg_use_fftw3_singlethread)
-else()
-    list(APPEND EXTRA_LIBRARIES ${FFTW3_LIBRARIES})
+  endif()
 endif()
 
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -273,17 +273,21 @@ add_definitions(-Dgmic_gui)
 add_definitions(-Dcimg_use_abort)
 add_definitions(-Dcimg_appname=\"gmic\")
 
-if (UNIX AND NOT APPLE)
-    add_definitions(-Dcimg_display=1)
-    add_definitions(-D_IS_LINUX_)
-    add_definitions(-Dcimg_use_vt100)
-    add_definitions(-D_IS_UNIX_)
-    find_package(X11)
-    set(gmic_qt_LIBRARIES
-        ${gmic_qt_LIBRARIES}
-        ${X11_LIBRARIES} # XXX: Search for X11: Wayland is coming!
-    )
-
+if (UNIX)
+    if(ANDROID)
+        add_definitions(-Dcimg_display=0)
+        add_definitions(-D_IS_UNIX_)
+    elseif(NOT APPLE)
+        add_definitions(-Dcimg_display=1)
+        add_definitions(-D_IS_LINUX_)
+        add_definitions(-Dcimg_use_vt100)
+        add_definitions(-D_IS_UNIX_)
+        find_package(X11)
+        set(gmic_qt_LIBRARIES
+            ${gmic_qt_LIBRARIES}
+            ${X11_LIBRARIES} # XXX: Search for X11: Wayland is coming!
+        )
+    endif()
 endif()
 
 if (APPLE)

--- a/cmake/modules/FindFFTW3.cmake
+++ b/cmake/modules/FindFFTW3.cmake
@@ -62,7 +62,7 @@ else()
 
     find_library(
         FFTW3_LIBRARY
-        NAMES libfftw3 libfftw3-3 libfftw3f-3 libfftw3l-3
+        NAMES libfftw3 libfftw3-3 libfftw3f-3 libfftw3l-3 fftw3
         DOC "Libraries to link against for FFT Support")
 
     if (FFTW3_LIBRARY)

--- a/src/FilterParameters/FloatParameter.cpp
+++ b/src/FilterParameters/FloatParameter.cpp
@@ -161,7 +161,7 @@ void FloatParameter::timerEvent(QTimerEvent * event)
 {
   killTimer(event->timerId());
   _timerId = 0;
-  if (not _spinBox->unfinishedKeyboardEditing()) {
+  if (!_spinBox->unfinishedKeyboardEditing()) {
     notifyIfRelevant();
   }
 }

--- a/src/FilterParameters/IntParameter.cpp
+++ b/src/FilterParameters/IntParameter.cpp
@@ -156,7 +156,7 @@ void IntParameter::timerEvent(QTimerEvent * e)
 {
   killTimer(e->timerId());
   _timerId = 0;
-  if (not _spinBox->unfinishedKeyboardEditing()) {
+  if (!_spinBox->unfinishedKeyboardEditing()) {
     notifyIfRelevant();
   }
 }

--- a/src/FilterParameters/PointParameter.cpp
+++ b/src/FilterParameters/PointParameter.cpp
@@ -202,7 +202,7 @@ void PointParameter::setVisibilityState(AbstractParameter::VisibilityState state
 
 void PointParameter::updateView()
 {
-  if (not _spinBoxX) {
+  if (!_spinBoxX) {
     return;
   }
   disconnectSpinboxes();

--- a/src/FilterSelector/FiltersPresenter.cpp
+++ b/src/FilterSelector/FiltersPresenter.cpp
@@ -270,7 +270,7 @@ void FiltersPresenter::selectFilterFromHash(QString hash, bool notify)
       hashExists = false;
     }
   }
-  if (not hashExists) {
+  if (!hashExists) {
     hash.clear();
   }
   setCurrentFilter(hash);
@@ -568,12 +568,12 @@ void FiltersPresenter::onTagToggled(int)
 
 bool FiltersPresenter::danglingFaveIsSelected() const
 {
-  if (not _filtersView || not _filtersView->aFaveIsSelected()) {
+  if (!_filtersView || !_filtersView->aFaveIsSelected()) {
     return false;
   }
   QString hash = _filtersView->selectedFilterHash();
   if (_favesModel.contains(hash)) {
-    return not _filtersModel.contains(_favesModel.getFaveFromHash(hash).originalHash());
+    return !_filtersModel.contains(_favesModel.getFaveFromHash(hash).originalHash());
   }
   return false;
 }

--- a/src/HeadlessProcessor.cpp
+++ b/src/HeadlessProcessor.cpp
@@ -271,7 +271,7 @@ void HeadlessProcessor::endApplication(const QString & errorMessage)
   if (!errorMessage.isEmpty()) {
     Logger::error(errorMessage);
   }
-  QCoreApplication::exit(not errorMessage.isEmpty());
+  QCoreApplication::exit(!errorMessage.isEmpty());
 }
 
 } // namespace GmicQt

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -407,7 +407,7 @@ void MainWindow::retrieveFilterAndParametersFromPluginParameters(QString & hash,
     const FiltersPresenter::Filter & filter = _filtersPresenter->currentFilter();
     if (!plainPath.isEmpty()) {
       _filtersPresenter->selectFilterFromAbsolutePathOrPlainName(plainPath);
-      if (not filter.isValid()) {
+      if (!filter.isValid()) {
         throw tr("Plugin was called with a filter path with no matching filter:\n\nPath: %1").arg(QString::fromStdString(_pluginParameters.filterPath));
       }
     }

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -31,6 +31,7 @@
 #include <QFileInfo>
 #include <QRegExp>
 #include <QString>
+#include <QStandardPaths>
 #include <QTemporaryFile>
 #include "Common.h"
 #include "Host/GmicQtHost.h"
@@ -50,7 +51,12 @@ namespace GmicQt
 
 const QString & gmicConfigPath(bool create)
 {
-  QString qpath = QString::fromUtf8(gmic::path_rc());
+#ifdef Q_OS_ANDROID
+  QString baseAppPath = QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation);
+  QString qpath = QString::fromLocal8Bit(gmic::path_rc(qPrintable(baseAppPath)));
+#else
+  QString qpath = QString::fromLocal8Bit(gmic::path_rc());
+#endif
   QFileInfo dir(qpath);
   static QString result;
   if (dir.isDir()) {


### PR DESCRIPTION
👋 

This PR upstreams the changes I did as part of the plugin port for Krita. The changes are:

- Fixed unary boolean operators (`not` -> `!`), making G'MIC-Qt compatible with MSVC
- Added LTO support for MSVC
- Added Android detection and support; with these adjustments, G'MIC can be built and run successfully (provided a host is compatible)
- Finally, I fixed FFTW Threads detection and usage on Windows 