### PR TITLE
GMIC_DYNAMIC_LINKING : Add option to allow libgmic.so being put at the same location as the plug-in binary

### DIFF
--- a/gmic_qt.pro
+++ b/gmic_qt.pro
@@ -406,7 +406,7 @@ SOURCES += \
 
 equals(GMIC_DYNAMIC_LINKING, "on" ) {
   message(Dynamic linking with libgmic)
-  LIBS += $$GMIC_PATH/libgmic.so
+  LIBS += -Wl,-rpath,. $$GMIC_PATH/libgmic.so
 }
 
 equals(GMIC_DYNAMIC_LINKING, "off" ) {


### PR DESCRIPTION
This option provides a way for the user to copy both files 'gmic_gimp_qt' and 'libgmic.so.3' at the same location and have the plug-in work as expected
(rather than copying 'gmic_gimp_qt' in '/lib/gimp/2.0/plug-ins/' and 'libgmic.so.3' in '/usr/lib/').
This eases the installation when using the .zip file from the G'MIC website.