### PR TITLE
Add gmic_core to the preprocessor definitions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -283,6 +283,7 @@ endif()
 
 add_definitions(-Dgmic_build)
 add_definitions(-Dgmic_community)
+add_definitions(-Dgmic_core)
 add_definitions(-Dcimg_use_abort)
 add_definitions(-Dgmic_is_parallel)
 add_definitions(-Dgmic_gui)


### PR DESCRIPTION
This is required to build G'MIC 3.0.2 with CImg.
