### PR TITLE
File 'gmic_qt.pro': Add dependency to 'libjpeg' by default.

### DIFF
--- a/gmic_qt.pro
+++ b/gmic_qt.pro
@@ -56,7 +56,7 @@ QT_CONFIG -= no-pkg-config
 CONFIG += link_pkgconfig
 VERSION = 0.0.0
 
-PKGCONFIG += fftw3 zlib libpng libcurl
+PKGCONFIG += fftw3 zlib libpng libjpeg libcurl
 
 equals( HOST, "gimp" ) {
   PKGCONFIG += gimp-2.0
@@ -68,7 +68,7 @@ equals( HOST, "gimp3" ) {
 
 DEFINES += cimg_use_cpp11=1
 DEFINES += cimg_use_fftw3 cimg_use_zlib
-DEFINES += gmic_core cimg_use_abort gmic_is_parallel cimg_use_curl cimg_use_png
+DEFINES += gmic_core cimg_use_abort gmic_is_parallel cimg_use_curl cimg_use_png cimg_use_jpeg
 DEFINES += cimg_appname="\\\"gmic\\\""
 
 equals(TIMING, "on") {


### PR DESCRIPTION
One of the last G'MIC filters (`Rendering / Generate Random Portrait`) requires G'MIC-Qt to be able to load JPEG image data from the network. Currently, G'MIC-Qt is not compiled with the libjpeg support enabled.
This PR enables a new dependency to `libjpeg` by default.

Note that a similar modification has to be done for the file `CMakeLists.txt`, but I don't know how to do it properly :)