### PR TITLE
Fix signature of institutions logos toggling

### DIFF
--- a/src/DialogSettings.cpp
+++ b/src/DialogSettings.cpp
@@ -144,7 +144,7 @@ void DialogSettings::done(int r)
   QDialog::done(r);
 }
 
-void DialogSettings::onVisibleLogosToggled(bool on)
+void DialogSettings::onLogosVisibleToggled(bool on)
 {
   Settings::setVisibleLogos(on);
 }

--- a/src/DialogSettings.h
+++ b/src/DialogSettings.h
@@ -54,7 +54,7 @@ public slots:
   void onUpdatePeriodicityChanged(int i);
   void onColorDialogsToggled(bool);
   void done(int r) override;
-  void onVisibleLogosToggled(bool);
+  void onLogosVisibleToggled(bool);
   void onPreviewTimeoutChange(int);
   void onOutputMessageModeChanged(int);
   void onPreviewZoomToggled(bool);


### PR DESCRIPTION
Hi @c-koi,

In https://github.com/c-koi/gmic-qt/commit/d824a99d2ab1803842fe29e5ca633257e19bca13, you slightly changed the name of the slot governing the visibility of your lab's logos, without changing the connection likewise. 

This PR reverts that specific change, fixing the checkbox and its logic.