### PR TITLE
Rename '_gmic_qt_persistent' to '_persistent'.

### DIFF
--- a/src/FilterSyncRunner.cpp
+++ b/src/FilterSyncRunner.cpp
@@ -159,12 +159,12 @@ void FilterSyncRunner::run()
       Logger::log(fullCommandLine, _logSuffix, true);
     }
     gmic gmicInstance(_environment.isEmpty() ? nullptr : QString("%1").arg(_environment).toLocal8Bit().constData(), GmicStdLib::Array.constData(), true, 0, 0, 0.f);
-    gmicInstance.set_variable("_gmic_qt_persistent", PersistentMemory::image());
+    gmicInstance.set_variable("_persistent", PersistentMemory::image());
     gmicInstance.set_variable("_host", '=', GmicQtHost::ApplicationShortname);
     gmicInstance.set_variable("_tk", '=', "qt");
     gmicInstance.run(fullCommandLine.toLocal8Bit().constData(), *_images, *_imageNames, &_gmicProgress, &_gmicAbort);
     _gmicStatus = gmicInstance.status;
-    gmicInstance.get_variable("_gmic_qt_persistent").move_to(*_persistentMemoryOuptut);
+    gmicInstance.get_variable("_persistent").move_to(*_persistentMemoryOuptut);
   } catch (gmic_exception & e) {
     _images->assign();
     _imageNames->assign();

--- a/src/FilterThread.cpp
+++ b/src/FilterThread.cpp
@@ -216,12 +216,12 @@ void FilterThread::run()
       Logger::log(fullCommandLine, _logSuffix, true);
     }
     gmic gmicInstance(_environment.isEmpty() ? nullptr : QString("%1").arg(_environment).toLocal8Bit().constData(), GmicStdLib::Array.constData(), true, nullptr, nullptr, 0.0f);
-    gmicInstance.set_variable("_gmic_qt_persistent", PersistentMemory::image());
+    gmicInstance.set_variable("_persistent", PersistentMemory::image());
     gmicInstance.set_variable("_host", '=', GmicQtHost::ApplicationShortname);
     gmicInstance.set_variable("_tk", '=', "qt");
     gmicInstance.run(fullCommandLine.toLocal8Bit().constData(), *_images, *_imageNames, &_gmicProgress, &_gmicAbort);
     _gmicStatus = gmicInstance.status;
-    gmicInstance.get_variable("_gmic_qt_persistent").move_to(*_persistentMemoryOuptut);
+    gmicInstance.get_variable("_persistent").move_to(*_persistentMemoryOuptut);
   } catch (gmic_exception & e) {
     _images->assign();
     _imageNames->assign();


### PR DESCRIPTION
Finally, to be coherent with how other variable names are defined by the plug-in (`_preview_width`, ...) , `_gmic_qt_persistent` should be indeed renamed to `_persistent`.
