### PR TITLE
[8bf] Add support for color managment and 32-bit floating point image data

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -655,15 +655,25 @@ elseif (${GMIC_QT_HOST} STREQUAL "paintdotnet")
 
 elseif (${GMIC_QT_HOST} STREQUAL "8bf")
 
-    set (gmic_qt_SRCS ${gmic_qt_SRCS} src/Host/8bf/host_8bf.cpp)
-    qt5_wrap_ui(gmic_qt_SRCS ${gmic_qt_FORMS})
-    add_definitions(-DGMIC_HOST=plugin8bf)
-    add_executable(gmic_8bf_qt ${gmic_qt_SRCS} ${gmic_qt_QRC})
-    target_link_libraries(
-      gmic_8bf_qt
-      PRIVATE
-      ${gmic_qt_LIBRARIES}
-      )
+  # Look for a CMake package on MSVC or a PkgConfig file on MinGW etc.
+  if (MSVC)
+    find_package(lcms2 CONFIG REQUIRED)
+    include_directories(${LCMS2_INCLUDE_DIR})
+  else()
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(LCMS2 REQUIRED lcms2)
+  endif()
+  
+  set (gmic_qt_SRCS ${gmic_qt_SRCS} src/Host/8bf/host_8bf.cpp)
+  qt5_wrap_ui(gmic_qt_SRCS ${gmic_qt_FORMS})
+  add_definitions(-DGMIC_HOST=plugin8bf)
+  add_executable(gmic_8bf_qt ${gmic_qt_SRCS} ${gmic_qt_QRC})
+  target_link_libraries(
+    gmic_8bf_qt
+    PRIVATE
+    ${gmic_qt_LIBRARIES}
+	${LCMS2_LIBRARIES}
+    )
 
 else()
     message(FATAL_ERROR "GMIC_QT_HOST is not defined as gimp, gimp3, krita, none, paintdotnet or 8bf")

--- a/gmic_qt.pro
+++ b/gmic_qt.pro
@@ -63,6 +63,10 @@ equals( HOST, "gimp3" ) {
   PKGCONFIG += gimp-3.0
 }
 
+equals( HOST, "8bf") {
+  PKGCONFIG += lcms2
+}
+
 DEFINES += cimg_use_cpp11=1
 DEFINES += cimg_use_fftw3 cimg_use_zlib
 DEFINES += cimg_use_abort gmic_is_parallel cimg_use_curl cimg_use_png cimg_use_jpeg

--- a/src/Host/8bf/host_8bf.cpp
+++ b/src/Host/8bf/host_8bf.cpp
@@ -2342,9 +2342,18 @@ void outputImages(gmic_list<float> & images, const gmic_list<char> & imageNames,
     }
 }
 
-void applyColorProfile(cimg_library::CImg<gmic_pixel_type> & images)
+void applyColorProfile(cimg_library::CImg<gmic_pixel_type> & image)
 {
-    unused(images);
+	if (!image)
+	{
+		return;
+	}
+	
+    if (host_8bf::grayScale && (image.spectrum() == 3 || image.spectrum() == 4))
+	{
+		// Convert the RGB image to grayscale.
+		GmicQt::calibrateImage(image, image.spectrum() == 4 ? 2 : 1, false);
+	}
 }
 
 void showMessage(const char * message)

--- a/src/Host/8bf/host_8bf.cpp
+++ b/src/Host/8bf/host_8bf.cpp
@@ -652,8 +652,8 @@ namespace
 
         return InputFileParseStatus::Ok;
     }
-	
-	InputFileParseStatus CopyTileToGmicImage32Interleaved(
+
+    InputFileParseStatus CopyTileToGmicImage32Interleaved(
         const float* tileBuffer,
         size_t tileBufferStride,
         int left,
@@ -1011,9 +1011,9 @@ namespace
         case 16:
             status = ConvertGmic8bfInputToGmicImage16(dataStream, inTileWidth, inTileHeight, numberOfChannels, planar, image);
             break;
-		case 32:
-		    status = ConvertGmic8bfInputToGmicImage32(dataStream, inTileWidth, inTileHeight, numberOfChannels, planar, image);
-			break;
+        case 32:
+            status = ConvertGmic8bfInputToGmicImage32(dataStream, inTileWidth, inTileHeight, numberOfChannels, planar, image);
+            break;
         default:
             status = InputFileParseStatus::InvalidArgument;
             break;
@@ -1742,8 +1742,8 @@ namespace
             }
         }
     }
-	
-	void WriteGmicOutputTile32Interleaved(
+
+    void WriteGmicOutputTile32Interleaved(
         QDataStream& dataStream,
         const cimg_library::CImg<float>& in,
         float* rowBuffer,
@@ -2334,9 +2334,9 @@ void outputImages(gmic_list<float> & images, const gmic_list<char> & imageNames,
             case 16:
                 WriteGmicOutput16(outputPath, in, planar, tileWidth, tileHeight);
                 break;
-			case 32:
-			    WriteGmicOutput32(outputPath, in, planar, tileWidth, tileHeight);
-				break;
+            case 32:
+                WriteGmicOutput32(outputPath, in, planar, tileWidth, tileHeight);
+                break;
             }
         }
     }
@@ -2344,16 +2344,16 @@ void outputImages(gmic_list<float> & images, const gmic_list<char> & imageNames,
 
 void applyColorProfile(cimg_library::CImg<gmic_pixel_type> & image)
 {
-	if (!image)
-	{
-		return;
-	}
-	
+    if (!image)
+    {
+        return;
+    }
+
     if (host_8bf::grayScale && (image.spectrum() == 3 || image.spectrum() == 4))
-	{
-		// Convert the RGB image to grayscale.
-		GmicQt::calibrateImage(image, image.spectrum() == 4 ? 2 : 1, false);
-	}
+    {
+        // Convert the RGB image to grayscale.
+        GmicQt::calibrateImage(image, image.spectrum() == 4 ? 2 : 1, false);
+    }
 }
 
 void showMessage(const char * message)


### PR DESCRIPTION
The 32-bits-per-channel output of the 8bf filter plug-in does not always match GIMP.
This is probably due to differences in how GIMP and the various 8bf plug-in hosts display 32-bits-per-channel image data.

Added color management for the G'MIC-Qt preview, this adds a `lcms2` dependency when building the 8bf host.
G'MIC-Qt will attempt to retrieve the color profile for the display that G'MIC-Qt is using when the first call to `applyColorProfile` is made, if that is unsuccessful the color profile of the primary display will be used.
The display color profile will not be refreshed if the user moves the G'MIC-Qt UI to a different display within the same session.
