### PR TITLE
Fix calls to gmic interpreter using simplified API of run().

### DIFF
--- a/src/FilterSyncRunner.cpp
+++ b/src/FilterSyncRunner.cpp
@@ -160,7 +160,7 @@ void FilterSyncRunner::run()
     gmicInstance.set_variable("_persistent", PersistentMemory::image());
     gmicInstance.set_variable("_host", '=', GmicQtHost::ApplicationShortname);
     gmicInstance.set_variable("_tk", '=', "qt");
-    gmicInstance.run(fullCommandLine.toLocal8Bit().constData(), *_images, *_imageNames, &_gmicProgress, &_gmicAbort);
+    gmicInstance.run(fullCommandLine.toLocal8Bit().constData(), *_images, *_imageNames);
     _gmicStatus = QString::fromLocal8Bit(gmicInstance.status);
     gmicInstance.get_variable("_persistent").move_to(*_persistentMemoryOuptut);
   } catch (gmic_exception & e) {

--- a/src/FilterThread.cpp
+++ b/src/FilterThread.cpp
@@ -217,7 +217,7 @@ void FilterThread::run()
     gmicInstance.set_variable("_persistent", PersistentMemory::image());
     gmicInstance.set_variable("_host", '=', GmicQtHost::ApplicationShortname);
     gmicInstance.set_variable("_tk", '=', "qt");
-    gmicInstance.run(fullCommandLine.toLocal8Bit().constData(), *_images, *_imageNames, &_gmicProgress, &_gmicAbort);
+    gmicInstance.run(fullCommandLine.toLocal8Bit().constData(), *_images, *_imageNames);
     _gmicStatus = QString::fromLocal8Bit(gmicInstance.status);
     gmicInstance.get_variable("_persistent").move_to(*_persistentMemoryOuptut);
   } catch (gmic_exception & e) {


### PR DESCRIPTION
I've simplified the API of `gmic::run()`, by removing the need for arguments `p_progress` and `p_is_abort` (only passed through the constructors now).
This fixes the compilation of the plug-in with this simplified G'MIC API.