### PR TITLE
CMake: actually fix ENABLE_SYSTEM_GMIC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -562,12 +562,53 @@ set (gmic_qt_FORMS
 
 if(ENABLE_DYNAMIC_LINKING)
   set(CMAKE_SKIP_RPATH TRUE)
-  set(gmic_qt_LIBRARIES
-    ${gmic_qt_LIBRARIES}
-    "gmic"
+  # G'MIC-Qt needs visibility into the private symbols defined
+  # by the gmic.cpp plugin. However, this is only possible
+  # if the library is static OR if it's dynamic and built by
+  # a compiler that supports .so-style exports.
+  if (TARGET libgmicstatic OR MSVC OR NOT ENABLE_SYSTEM_GMIC)
+    set(gmic_qt_LIBRARIES
+      ${gmic_qt_LIBRARIES}
+      libgmicstatic
     )
+  elseif(TARGET libgmic)
+    set(gmic_qt_LIBRARIES
+      ${gmic_qt_LIBRARIES}
+      libgmic
+    )
+  elseif(GMIC_LIB_PATH)
+    set(gmic_qt_LIBRARIES
+      ${gmic_qt_LIBRARIES}
+      "gmic"
+    )
+  else()
+    message(FATAL_ERROR "No G'MIC library is available for linking. Please build libgmic as a static library.")
+  endif()
   if (NOT ENABLE_SYSTEM_GMIC)
-    link_directories(${GMIC_LIB_PATH})
+    if (GMIC_LIB_PATH)
+      link_directories(${GMIC_LIB_PATH})
+      # Inject the G'MIC CImg plugin.
+      include_directories(../src)
+    else()
+      # Mimic an external G'MIC library build for catching link ABI errors.
+      add_library(libgmicstatic STATIC ../src/gmic.cpp)
+      target_include_directories(libgmicstatic PUBLIC ../src)
+      # We need internal access into the gmic-core API.
+      target_compile_definitions(libgmicstatic PUBLIC gmic_core)
+      set_target_properties(libgmicstatic
+        PROPERTIES
+          AUTOMOC OFF
+      )
+      target_link_libraries(libgmicstatic PUBLIC
+        ${PNG_LIBRARIES}
+        ${FFTW3_LIBRARIES}
+        ${ZLIB_LIBRARIES}
+        ${CURL_LIBRARIES}
+        ${EXTRA_LIBRARIES})
+    endif()
+  else()
+    # Inject the G'MIC CImg plugin.
+    include_directories(../src)
   endif()
 else(ENABLE_DYNAMIC_LINKING)
   set(gmic_qt_SRCS


### PR DESCRIPTION
PR c-koi/gmic-qt#172 is correct in that it is no longer possible to build without `-Dgmic_core`, due to G'MIC-Qt relying in now-private implementation details of G'MIC; namely, the extensions made in gmic.cpp to CImg.

However, the solution chosen has significant shortcomings:

1. It blindly assumes that the consumed library has been built by a GCC-compatible compiler. This is easily inferred from the lack of symbol exports in {CImg,gmic}.{h,cpp}.
2. It makes no provision for the exported library type; G'MIC can be built statically or dynamically.
3. In Windows, when built with MSVC, the kind of symbol export that gmic_core implies is only available with a static libgmic.

To fix this, this commit augments G'MIC-Qt's `ENABLE_DYNAMIC_LINKING` handling with target detection code for the above described cases. In the case where a compatible library is not found, a fallback is specified that will build libgmic as a separate target, then make G'MIC-Qt link against it in order to mimic the requirements. If a suitable system library is found, we augment it with the gmic.cpp plugin to make the symbols visible at compile time.

This is a less-invasive alternative to #174 that fixes building on MSVC too.

Closes #174