### PR TITLE
Fix CMake build with 3.2.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -560,18 +560,18 @@ set(gmic_qt_SRCS
 )
 
 set (gmic_qt_FORMS
-  dialogsettings.ui
-  filtersview.ui
-  headlessprogressdialog.ui
-  inoutpanel.ui
-  languageselectionwidget.ui
-  mainwindow.ui
-  multilinetextparameterwidget.ui
-  progressinfowidget.ui
-  progressinfowindow.ui
-  SearchFieldWidget.ui
-  sourceswidget.ui
-  zoomlevelselector.ui
+  ui/dialogsettings.ui
+  ui/filtersview.ui
+  ui/headlessprogressdialog.ui
+  ui/inoutpanel.ui
+  ui/languageselectionwidget.ui
+  ui/mainwindow.ui
+  ui/multilinetextparameterwidget.ui
+  ui/progressinfowidget.ui
+  ui/progressinfowindow.ui
+  ui/SearchFieldWidget.ui
+  ui/sourceswidget.ui
+  ui/zoomlevelselector.ui
 )
 
 if(ENABLE_DYNAMIC_LINKING)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -433,8 +433,6 @@ set (gmic_qt_SRCS
   src/GmicStdlib.h
   src/HeadlessProcessor.h
   src/Host/GmicQtHost.h
-  src/Host/None/ImageDialog.h
-  src/Host/None/JpegQualityDialog.h
   src/HtmlTranslator.h
   src/IconLoader.h
   src/ImageTools.h
@@ -524,12 +522,6 @@ set(gmic_qt_SRCS
   src/GmicQt.cpp
   src/GmicStdlib.cpp
   src/HeadlessProcessor.cpp
-  src/Host/8bf/host_8bf.cpp
-  src/Host/Gimp/host_gimp.cpp
-  src/Host/None/host_none.cpp
-  src/Host/None/ImageDialog.cpp
-  src/Host/None/JpegQualityDialog.cpp
-  src/Host/PaintDotNet/host_paintdotnet.cpp
   src/HtmlTranslator.cpp
   src/IconLoader.cpp
   src/ImageTools.cpp


### PR DESCRIPTION
These were changed in eb5e2ad49 but it's not entirely clear why

The changed paths for the Qt forms aren't their real location, and it seems all of the host code was added for the default build, even though only the source files for the given `GMIC_QT_HOST` are needed and are conditionally added further down in the CMakeLists

I needed both of the commits in this PR for the CMake build to work for me (otherwise it errors out about UI form headers not being found and doesn't build with Qt5 because the 8bf host requires Qt6)

Am I missing anything or was this stuff just changed by mistake?

Thank you!