### PR TITLE
Fix build on NetBSD.

### DIFF
--- a/gmic_qt.pro
+++ b/gmic_qt.pro
@@ -180,7 +180,7 @@ win32 {
  DEFINES += cimg_display=2
 }
 
-linux {
+unix:!macx {
   DEFINES += _IS_LINUX_
   PKGCONFIG += x11
   message( Linux platform )


### PR DESCRIPTION
Actually, handle all non-macOS Unixes the same way as Linux.

I think that's a safer default; possibly the 'message' should be updated as well but I'm not sure to what exactly.

Exclude macOS because one usually wants to avoid X11 there.